### PR TITLE
README: taskDefinition.name should be taskDefinition.family

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ var deployer = new EcsDeployer({
   services: [
     {
       taskDefinition: {
-        "name": "foo" // This should already exist in ECS. Required.
+        "family": "foo" // This should already exist in ECS. Required.
       },
 
       name: 'my-web-service', // ECS service name. Required.


### PR DESCRIPTION
That is what the code uses. Fixes error of form:

Failed to deploy
{ [MissingRequiredParameter: Missing required key 'taskDefinition' in params]
  message: 'Missing required key \'taskDefinition\' in params',
  code: 'MissingRequiredParameter',
  time: Tue Nov 10 2015 21:29:27 GMT+0100 (CET) }
